### PR TITLE
docs: link the TF GitHub repo as the source

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@
 Using this template in a new project? See CONTIBUTING.md for help.
 --->
 
-This repo contains instructions for the ["Nutanix on Equinix Metal" workshop](https://equinix-labs.github.io/nutanix-on-equinix-metal-workshop).
+This repo contains workshop instructions to be used with the [Nutanix Cluster on Equinix Metal Terraform module](https://github.com/equinix-labs/terraform-equinix-metal-nutanix-cluster).
 
 To view the workshop, visit <https://equinix-labs.github.io/nutanix-on-equinix-metal-workshop>


### PR DESCRIPTION
Rather than linking twice to the Workshop, link to the upstream source GitHub repo and the workshop. (The source for the workshop is the thing folks are already looking at.)